### PR TITLE
fix: python2 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 MAINTAINER uli.hitzel@gmail.com
 EXPOSE 8080
 RUN apk update
-RUN apk add python2
+RUN apk add python3
 COPY app/index.html /tmp/index.html
 COPY app/start.sh /tmp/start.sh
 USER 1000

--- a/app/start.sh
+++ b/app/start.sh
@@ -3,4 +3,4 @@ mkdir www
 cp index.html www
 echo "<hr>Running on $(hostname)" >> www/index.html
 cd www
-python -m SimpleHTTPServer 8080
+python3 -m http.server 8080


### PR DESCRIPTION
For some reason alpine throws error `python2 (no such package)`. This fixes it by moving to python3.

```
docker build . -t myhello
[+] Building 6.3s (7/9)                                                                                                                                 
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 240B                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                   3.9s
 => [internal] load build context                                                                                                                  0.0s
 => => transferring context: 250B                                                                                                                  0.0s
 => [1/5] FROM docker.io/library/alpine@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c                                    0.6s
 => => resolve docker.io/library/alpine@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c                                    0.0s
 => => sha256:6e30ab57aeeef1ebca8ac5a6ea05b5dd39d54990be94e7be18bb969a02d10a3f 1.49kB / 1.49kB                                                     0.0s
 => => sha256:b3c136eddcbf2003d3180787cef00f39d46b9fd9e4623178282ad6a8d63ad3b0 2.69MB / 2.69MB                                                     0.4s
 => => sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c 1.64kB / 1.64kB                                                     0.0s
 => => sha256:c3c58223e2af75154c4a7852d6924b4cc51a00c821553bbd9b3319481131b2e0 528B / 528B                                                         0.0s
 => => extracting sha256:b3c136eddcbf2003d3180787cef00f39d46b9fd9e4623178282ad6a8d63ad3b0                                                          0.2s
 => [2/5] RUN apk update                                                                                                                           1.4s
 => ERROR [3/5] RUN apk add python2                                                                                                                0.3s
------                                                                                                                                                  
 > [3/5] RUN apk add python2:                                                                                                                           
#6 0.270   python2 (no such package):                                                                                                                   
#6 0.270 ERROR: unable to select packages:
#6 0.285     required by: world[python2]
------
executor failed running [/bin/sh -c apk add python2]: exit code: 1
```